### PR TITLE
Align Timers for Copy of Verification Vector

### DIFF
--- a/cuda/Simulation.cu
+++ b/cuda/Simulation.cu
@@ -27,6 +27,10 @@ unsigned long long run_event_based_simulation_baseline(Inputs in, SimulationData
 	gpuErrchk( cudaPeekAtLastError() );
 	gpuErrchk( cudaDeviceSynchronize() );
 
+    size_t sz = in.lookups * sizeof(unsigned long);
+	unsigned long * v = (unsigned long *) malloc(sz);
+	gpuErrchk( cudaMemcpy(v, GSD.verification, sz, cudaMemcpyDeviceToHost) );
+
 #ifdef ALIGNED_WORK
 	*end = get_time();
 #endif
@@ -34,13 +38,12 @@ unsigned long long run_event_based_simulation_baseline(Inputs in, SimulationData
 	////////////////////////////////////////////////////////////////////////////////
 	// Reduce Verification Results
 	////////////////////////////////////////////////////////////////////////////////
+
 	if( mype == 0)	printf("Reducing verification results...\n");
 
-	unsigned long long verification_scalar;
-
-	verification_scalar = thrust::reduce(thrust::device, GSD.verification, GSD.verification + in.lookups, 0);
-	gpuErrchk( cudaPeekAtLastError() );
-	gpuErrchk( cudaDeviceSynchronize() );
+	unsigned long verification_scalar = 0;
+	for( int i =0; i < in.lookups; i++ )
+		verification_scalar += v[i];
 
 	return verification_scalar;
 }

--- a/hip/Simulation.cpp
+++ b/hip/Simulation.cpp
@@ -28,6 +28,10 @@ unsigned long long run_event_based_simulation_baseline(Inputs in, SimulationData
 	gpuErrchk( hipPeekAtLastError() );
 	gpuErrchk( hipDeviceSynchronize() );
 
+	size_t sz = in.lookups * sizeof(unsigned long);
+	unsigned long * v = (unsigned long *) malloc(sz);
+	gpuErrchk( hipMemcpy(v, GSD.verification, sz, hipMemcpyDeviceToHost) );
+
 #ifdef ALIGNED_WORK
 	*end = get_time();
 #endif
@@ -36,11 +40,6 @@ unsigned long long run_event_based_simulation_baseline(Inputs in, SimulationData
 	// Reduce Verification Results
 	////////////////////////////////////////////////////////////////////////////////
 	if( mype == 0)	printf("Reducing verification results...\n");
-
-
-	size_t sz = in.lookups * sizeof(unsigned long);
-	unsigned long * v = (unsigned long *) malloc(sz);
-	gpuErrchk( hipMemcpy(v, GSD.verification, sz, hipMemcpyDeviceToHost) );
 
 	unsigned long verification_scalar = 0;
 	for( int i =0; i < in.lookups; i++ )

--- a/raja/Main.cpp
+++ b/raja/Main.cpp
@@ -80,7 +80,7 @@ int main( int argc, char* argv[] )
 	if( in.simulation_method == EVENT_BASED )
 	{
 		if( in.kernel_id == 0 )
-			verification = run_event_based_simulation(in, SD, mype);
+			verification = run_event_based_simulation(in, SD, mype, &omp_end);
 		else if( in.kernel_id == 1 )
 			verification = run_event_based_simulation_optimization_1(in, SD, mype);
 		else
@@ -99,8 +99,9 @@ int main( int argc, char* argv[] )
 	}
 
 	// End Simulation Timer
+#ifndef ALIGNED_WORK
 	omp_end = get_time();
-
+#endif
 	// =====================================================================
 	// Output Results & Finalize
 	// =====================================================================

--- a/raja/Makefile
+++ b/raja/Makefile
@@ -23,6 +23,7 @@ MPI         ?= no
 RAJA_DEVICES ?= Cuda#OpenMP#,Cuda
 RAJA_ARCH ?= Power9# Zen3,Ampere80
 SM_VERSION ?= 70
+ALIGNED ?= yes
 
 #===============================================================================
 # Program name & source code list
@@ -103,6 +104,10 @@ endif
 ifeq ($(MPI),yes)
   CXX = mpicxx
   CXXFLAGS += -DMPI
+endif
+
+ifeq ($(ALIGNED),yes)
+  CFLAGS += -DALIGNED_WORK
 endif
 
 #===============================================================================

--- a/raja/Simulation.cpp
+++ b/raja/Simulation.cpp
@@ -19,7 +19,7 @@ using policy = RAJA::cuda_exec<256>;
 #endif
 
 
-unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype)
+unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype, double* end)
 {
 	if( mype == 0)	
 		printf("Beginning event based simulation...\n");
@@ -136,6 +136,10 @@ unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int 
 	// cudaDeviceSynchronize();
 	// Copy back the verifications and do a sum to get the verification hash
 	rm.copy(verifications, d_verifications);
+#ifdef ALIGNED_WORK
+    *end = get_time();
+#endif
+
 	unsigned long long verification_hash = 0;
 	for (std::size_t i = 0; i < in.lookups; i++) {
     	verification_hash += verifications[i];

--- a/raja/XSbench_header.hpp
+++ b/raja/XSbench_header.hpp
@@ -148,7 +148,7 @@ void binary_write( Inputs in, SimulationData SD );
 SimulationData binary_read( Inputs in );
 
 // Simulation.c
-unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype);
+unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int mype, double* end);
 unsigned long long run_history_based_simulation(Inputs in, SimulationData SD, int mype);
 RAJA_HOST_DEVICE void calculate_micro_xs(   double p_energy, int nuc, long n_isotopes,
                            long n_gridpoints,

--- a/sycl/Main.cpp
+++ b/sycl/Main.cpp
@@ -99,8 +99,9 @@ int main( int argc, char* argv[] )
 	}
 
 	// End Simulation Timer
+#ifndef ALIGNED_WORK
 	omp_end = get_time();
-
+#endif
 	// =====================================================================
 	// Output Results & Finalize
 	// =====================================================================

--- a/sycl/Makefile
+++ b/sycl/Makefile
@@ -94,8 +94,6 @@ ifeq ($(MPI),yes)
   CFLAGS += -DMPI
 endif
 
-LDFLAGS += -L/sw/summit/gcc/11.2.0-0/lib64
-
 ifeq ($(ALIGNED),yes)
   CFLAGS += -DALIGNED_WORK
 endif

--- a/sycl/Makefile
+++ b/sycl/Makefile
@@ -50,7 +50,7 @@ ifeq ($(COMPILER),llvm)
   CC = clang++
   CFLAGS += -fsycl 
   ifeq ($(USE_CUDA),yes)
-    CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70
+    CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda
   endif
   #LDFLAGS += -lOpenCL
 endif

--- a/sycl/Makefile
+++ b/sycl/Makefile
@@ -10,6 +10,7 @@ MPI         ?= no
 CHECK_MAX   ?= no
 USE_CUDA    ?= yes
 CUDA_ARCH   ?= sm_80
+ALIGNED     ?= yes
 
 #===============================================================================
 # Program name & source code list
@@ -47,9 +48,9 @@ endif
 # LLVM Compiler
 ifeq ($(COMPILER),llvm)
   CC = clang++
-  CFLAGS += -fsycl
+  CFLAGS += -fsycl 
   ifeq ($(USE_CUDA),yes)
-    CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda
+    CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70
   endif
   #LDFLAGS += -lOpenCL
 endif
@@ -91,6 +92,12 @@ endif
 ifeq ($(MPI),yes)
   CC = mpicc
   CFLAGS += -DMPI
+endif
+
+LDFLAGS += -L/sw/summit/gcc/11.2.0-0/lib64
+
+ifeq ($(ALIGNED),yes)
+  CFLAGS += -DALIGNED_WORK
 endif
 
 #===============================================================================

--- a/sycl/Simulation.cpp
+++ b/sycl/Simulation.cpp
@@ -171,6 +171,10 @@ unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int 
 		if(mype==0) printf("Beginning event based simulation...\n");
 	}
 
+#ifdef ALIGNED_WORK
+	stop = get_time();
+#endif
+
 	// Host reduces the verification array
 	unsigned long long verification_scalar = 0;
 	for( int i = 0; i < in.lookups; i++ )


### PR DESCRIPTION
The following models had to be changed to ensure that the copy of the verification vector back to the host from the device was included in the timing.
- CUDA
- HIP
- SYCL
- RAJA